### PR TITLE
SnapToGrid by LineMetric

### DIFF
--- a/word/Editor/Document.js
+++ b/word/Editor/Document.js
@@ -7321,6 +7321,32 @@ CDocument.prototype.Set_DocumentOrientation = function(Orientation, bNoRecalc)
 		this.Document_UpdateRulersState();
 	}
 };
+CDocument.prototype.Get_DocumentDocGrid = function()
+{
+	var CurPos = this.CurPos.ContentPos;
+	var SectPr = this.SectionsInfo.Get_SectPr(CurPos).SectPr;
+
+	return SectPr.DocGrid;
+}
+CDocument.prototype.Set_DocumentDocGrid = function(type, linePitch, charSpace, bNoRecalc)
+{
+	var CurPos = this.CurPos.ContentPos;
+	var SectPr = this.SectionsInfo.Get_SectPr(CurPos).SectPr;
+
+	SectPr.SetDocGridType(type);
+	SectPr.SetDocGridLinePitch(linePitch);
+	SectPr.SetDocGridCharSpace(charSpace);
+
+	this.DrawingObjects.CheckAutoFit();
+	if (true != bNoRecalc)
+	{
+		this.Recalculate();
+		this.Document_UpdateSelectionState();
+		this.Document_UpdateInterfaceState();
+		this.Document_UpdateRulersState();
+	}
+}
+
 CDocument.prototype.Get_DocumentOrientation = function()
 {
 	// TODO: Document.Get_DocumentOrientation Сделать в зависимости от выделения

--- a/word/Editor/Styles.js
+++ b/word/Editor/Styles.js
@@ -14586,7 +14586,9 @@ CTextMetrics.prototype.Update = function(oFontInfo)
 		this.Ascent = _nAscent;
 
 	if (this.LineGap < _nLineGap)
-		this.LineGap = _nLineGap;
+	  	this.LineGap = _nLineGap;
+    //this.LineGap = Math.max(0, this.Height - this.Ascent - this.Descent);
+
 };
 //----------------------------------------------------------------------------------------------------------------------
 // CTextPr Export

--- a/word/apiExt.js
+++ b/word/apiExt.js
@@ -575,6 +575,45 @@
         return undefined;
     }
 
+    // 计算文档网格可以设置的设置的最大行数
+    asc_docs_api.prototype.asc_GetMaxGridRows = function (height) {
+        var nPageHeight = AscCommon.MMToTwip(height);
+        var nGridHeight = 285;
+        var nGridRows = Math.floor(nPageHeight / nGridHeight);
+        return nGridRows;
+    }
+
+    // 根据行数计算一行高度
+    asc_docs_api.prototype.asc_CalcLinePitch = function (height, row) {
+        if (row == 0) {
+            return height;
+        }
+        var nPageHeight = AscCommon.MMToTwip(height);
+        return Math.floor(nPageHeight / row)        
+    }
+
+    asc_docs_api.prototype.asc_SetLines = function(lines)
+    {
+        var oLogicDocument = this.private_GetLogicDocument();
+        if (!oLogicDocument)
+            return;
+
+        var CurPos = oLogicDocument.CurPos.ContentPos;
+        var SectPr = oLogicDocument.SectionsInfo.Get_SectPr(CurPos).SectPr;
+
+        var DocGrid = SectPr.DocGrid;
+    
+        const height = SectPr.GetContentFrameHeight();
+        const maxLines = asc_GetMaxGridRows(height);
+        if (lines > maxLines) {
+            lines = maxLines;
+        }
+
+        var linePitch = asc_CalcLinePitch(height, lines);
+        
+        SectPr.SetDocGridLinePitch(linePitch);
+    }
+
 
     asc_docs_api.prototype["asc_GetParagraphBoundingRect"] = asc_docs_api.prototype.asc_GetParagraphBoundingRect;
     asc_docs_api.prototype["asc_GetParagraphNumberingBoundingRect"] = asc_docs_api.prototype.asc_GetParagraphNumberingBoundingRect;


### PR DESCRIPTION
用来新的方式来进行网格对齐，段前和段后间距不受网格对齐影响。
原来的网格对齐之修改了BaseLine的位置，会导致选择区域于绘制区域不一致。
在有网格对齐，并指定多倍行距倍，用网格对齐的行高作为计算基数。